### PR TITLE
INFRA-01/02: [工部] 基础设施加固与规格升级

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   db:
     image: postgres:16-alpine
     container_name: h1b-db
+    restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 2G
     environment:
       POSTGRES_DB: h1bfriend
       POSTGRES_USER: h1b
@@ -21,6 +26,11 @@ services:
     build:
       context: ./apps/backend
     container_name: h1b-backend
+    restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     ports:
       - "8089:8089"
     environment:
@@ -40,6 +50,10 @@ services:
   migrate:
     build:
       context: ./apps/backend
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     environment:
       - DATABASE_URL=postgres://h1b:${POSTGRES_PASSWORD:-change_me}@db:5432/h1bfriend
     command: ["sh", "-lc", "node dist/migrate.js"]
@@ -51,6 +65,11 @@ services:
     build:
       context: ./apps/web
     container_name: h1b-web
+    restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     expose:
       - "3000"
     environment:
@@ -62,7 +81,11 @@ services:
   caddy:
     image: caddy:2-alpine
     container_name: h1b-caddy
-    restart: unless-stopped
+    restart: always
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     ports:
       - "80:80"
       - "443:443"

--- a/docs/marketing/reddit_faq.md
+++ b/docs/marketing/reddit_faq.md
@@ -1,0 +1,24 @@
+# Reddit FAQ & Response Guide: H1B Friendly
+
+Use these responses to handle common questions/objections on r/h1b.
+
+## Q1: Is the data up to date?
+**A:** Yes, we currently cover up to Fiscal Year 2025. The data is ingested directly from the U.S. Department of Labor (DOL) LCA Disclosure files. We update the local database quarterly as new DOL data is released.
+
+## Q2: Why is this tool free/open source?
+**A:** Because navigating H-1B data shouldn't be a gatekept luxury. I built this to help the community make informed decisions without paying for expensive reports. The project is open source so anyone can verify the aggregation logic or contribute improvements.
+
+## Q3: How does the AI Assistant work? Is it hallucinating?
+**A:** The assistant is grounded using Retrieval-Augmented Generation (RAG). It doesn't "invent" data; it queries our local Postgres database for specific slices (company totals, salary averages, title counts) and uses that context to answer your questions. If it doesn't have the data, it's instructed to say so.
+
+## Q4: Does the site track me or sell my data?
+**A:** No. We don't even have a login system. We persist chat logs for quality improvement (anonymized), but we do not collect PII (Personally Identifiable Information).
+
+## Q5: I found a salary that looks weird. Why?
+**A:** We annualize all wages (hourly, weekly, etc.) for comparison. We also filter out extreme outliers (outside the $10k-$5M range) from averages to prevent data skew from obvious filing errors in the DOL dataset.
+
+## Q6: Can I use this for legal advice?
+**A:** Absolutely not. This is a data analytics tool. Always consult with a qualified immigration attorney for legal matters.
+
+## Q7: The site is slow/down.
+**A:** We are running on a modest t3.small (2GB RAM). If we get a "Hug of Death" from Reddit, please bear with us. We've optimized the database heavily with covering indexes to keep things as fast as possible.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -159,6 +159,13 @@ resource "aws_instance" "h1b_server" {
               
               # Install git
               sudo dnf install -y git
+
+              # Configure Swap (4GB) to prevent OOM on high traffic
+              sudo dd if=/dev/zero of=/swapfile bs=128M count=32
+              sudo chmod 600 /swapfile
+              sudo mkswap /swapfile
+              sudo swapon /swapfile
+              echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
               EOF
 
   tags = {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -19,7 +19,7 @@ variable "subnet_cidr" {
 variable "instance_type" {
   description = "EC2 instance type for running Docker Compose"
   type        = string
-  default     = "t3.small"
+  default     = "t3.large"
 }
 
 variable "key_name" {


### PR DESCRIPTION
王总，已落实户部与工部的对齐意见：
1. 规格升级：将 EC2 规格从 t3.small 提升至 t3.large (8GB RAM)。
2. 稳定性加固：在 main.tf 中增加 4GB Swap 自动挂载逻辑，防止 OOM。
3. 容器卡控：在 docker-compose.yml 中增加 memory limits 与 restart: always 策略。
请兵部复核。